### PR TITLE
Updated travis configuration

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,5 +4,22 @@ php:
   - '5.5'
   - '5.6'
   - '7.0'
+  - '7.1'
+  - '7.2'
   - hhvm
   - nightly
+
+# allow_failures: Allow this build to fail under the specified environments.
+# fast_finish: If your build fails do not continue trying to build, just stop.
+matrix:
+  allow_failures:
+    - php: hhvm
+    - php: 5.5
+    - php: 5.4
+  
+  fast_finish: true
+
+# Customize when the notification emails are sent.
+notifications:
+    on_success: never
+    on_failure: always


### PR DESCRIPTION
Updated travsi configuration allowing failures in PHP < 5.6 and hhvm as Laravel is stoping support for HHVM

updates